### PR TITLE
Fixes in Subtitulos.es plugin

### DIFF
--- a/periscope/plugins/Subtitulos.py
+++ b/periscope/plugins/Subtitulos.py
@@ -53,6 +53,12 @@ class Subtitulos(SubtitleDatabase.SubtitleDB):
         fname = unicode(self.getFileName(filepath).lower())
         guessedData = self.guessFileData(fname)
         if guessedData['type'] == 'tvshow':
+
+            if "es" in langs:
+                langs.append("es-es")
+                langs.append("es-la")
+            
+            log.debug("Languagess choosen: %s" % langs)
             subs = self.query(guessedData['name'], guessedData['season'], guessedData['episode'], guessedData['teams'], langs)
             return subs
         else:


### PR DESCRIPTION
I have made some changes in Subtitulos.es plugin to get it working again. All the changes are detailed in the commit message.

 Various fixes in subtitlos.es plugin
- Fixed bug in the search of the download links.
- Fixed the re used to compare tems and subteams.
- Added Galego in languages.
- Now Spanish (from Spain) and Spanish (from latin america) have been
  differntiated.
- Search "-l es" now look in both type of spanish languages
