### PR TITLE
Quickfix

### DIFF
--- a/periscope/periscope.py
+++ b/periscope/periscope.py
@@ -37,11 +37,10 @@ except ImportError:
     is_local = False
 
 import plugins
-import version
 import locale
 
 SUPPORTED_FORMATS = 'video/x-msvideo', 'video/quicktime', 'video/x-matroska', 'video/mp4'
-VERSION = version.VERSION
+VERSION = 'dev'
 
 class Periscope:
     ''' Main Periscope class'''


### PR DESCRIPTION
After pull request #40, a clean install on raspian (python 2.7) complained
about the missing version module. This fixes it :)