### PR TITLE
Don't fail if parent dir doesn't exist, create it

### DIFF
--- a/periscope/periscope.py
+++ b/periscope/periscope.py
@@ -51,7 +51,7 @@ class Periscope:
                 folder = os.path.dirname(self.config_file)
                 if not os.path.exists(folder):
                     logging.info("Creating folder %s" %folder)
-                    os.mkdir(folder)
+                    os.makedirs(folder)
                 logging.info("Creating config file")
                 configfile = open(self.config_file, "w")
                 self.config.write(configfile)


### PR DESCRIPTION
This is a simple one. It failed on my laptop because `~/.config` folder didn't exist. So, instead of using `os.mkdir`, we can use `os.makedirs` so that all parent directories are also created. 

